### PR TITLE
Damage system and pathfinding reset fixes

### DIFF
--- a/Game/src/Enemy.cpp
+++ b/Game/src/Enemy.cpp
@@ -69,6 +69,12 @@ bool Enemy::Start() {
 
 bool Enemy::Update(float dt)
 {
+	if (Engine::GetInstance().scene.get()->GameOverMenu == true) {
+		//// Initialize pathfinding
+		pathfinding = new Pathfinding();
+		ResetPath();
+	}
+
 	if (Engine::GetInstance().scene.get()->showPauseMenu == true || Engine::GetInstance().scene.get()->GameOverMenu == true || Engine::GetInstance().scene.get()->InitialScreenMenu == true) return true;
 
 	velocity = 0;

--- a/Game/src/Enemy.h
+++ b/Game/src/Enemy.h
@@ -89,8 +89,8 @@ public:
 	PhysBody* attackSensor;
 
 	Pathfinding* pathfinding;
-	bool followPlayer;
-	bool attackPlayer;
+	bool followPlayer = false;
+	bool attackPlayer = false;
 
 
 	Player* player;

--- a/Game/src/EntityManager.cpp
+++ b/Game/src/EntityManager.cpp
@@ -120,10 +120,12 @@ void EntityManager::AddEntity(Entity* entity)
 bool EntityManager::Update(float dt)
 {
 	bool ret = true;
-	for(const auto entity : entities)
-	{
-		if (entity->active == false) continue;
-		ret = entity->Update(dt);
+	if (!Engine::GetInstance().scene.get()->reset_level) {
+		for (const auto entity : entities)
+		{
+			if (entity->active == false) continue;
+			ret = entity->Update(dt);
+		}
 	}
 	return ret;
 }

--- a/Game/src/Player.cpp
+++ b/Game/src/Player.cpp
@@ -407,16 +407,19 @@ void Player::OnCollision(PhysBody* physA, PhysBody* physB) {
 
 		cleanup_pbody = true;
 		break;
+	case ColliderType::ENEMY:
 	case ColliderType::DAMAGE:
 		LOG("Colisión con daño detectada");
 
-		Engine::GetInstance().entityManager.get()->candleNum--;
-		if (Engine::GetInstance().entityManager.get()->candleNum > 0) {
-			//Engine::GetInstance().scene.get()->PreUpdate();
-			Engine::GetInstance().scene.get()->reset_level = true;
-
-
+		if (!takenDMG) {
+			Engine::GetInstance().entityManager.get()->candleNum--;
+			if (Engine::GetInstance().entityManager.get()->candleNum <= 0) {
+				//Engine::GetInstance().scene.get()->PreUpdate();
+				Engine::GetInstance().scene.get()->reset_level = true;
+			}
 		}
+
+		takenDMG = true;
 		break;
 		//Engine::GetInstance().scene.get()->drainedWaxy = false;
 	case ColliderType::WALL:
@@ -486,8 +489,10 @@ void Player::OnCollisionEnd(PhysBody* physA, PhysBody* physB)
 
 			cleanup_pbody = false;
 		}
+	case ColliderType::ENEMY:
 	case ColliderType::DAMAGE:
 		/*Engine::GetInstance().scene.get()->reset_level = true;*/
+		takenDMG = false;
 
 		break;
   case ColliderType::M_PLATFORM:


### PR DESCRIPTION
- all candles need to be lost before game over
- enemy pathfinding resets during game over to avoid crashes 

**future additions, not yet implemented:**
- enemy attack damage (timed with animation when implemented)
- water damage checkpoint (added when checkpoints are added), right now you can phase through the water after damage taken